### PR TITLE
Fixed 2 typos

### DIFF
--- a/01-communication.Rmd
+++ b/01-communication.Rmd
@@ -15,7 +15,7 @@ These communications guidelines are evolving as we increasingly adopt Slack, but
 ## Email
 
 - Use email for longer messages (>200 words) or messages that merit preservation. 
-- Generally, strive to respond within 24 hours hours. As noted above, if you are unusually busy or on vacation please alert the team in advance so ecan expect you not to respond at all / as quickly as usual. 
+- Generally, strive to respond within 24 hours hours. As noted above, if you are unusually busy or on vacation please alert the team in advance so we can expect you not to respond at all / as quickly as usual. 
 
 ## Trello
 

--- a/04-coding-practices.Rmd
+++ b/04-coding-practices.Rmd
@@ -88,7 +88,7 @@ We recommend you use **Snake_Case**.
 - **Note**: again, its also worth noting there's nothing inherently wrong with using `.` in variable names, just that it goes against style best practices that are cropping up in data science, so its worth getting rid of these bad habits now.
 
 ## Function calls
-In a function call, use "named arguments" and separate arguments by to make your code more readable. 
+In a function call, use "named arguments" and put each argument on a separate line to make your code more readable. 
 
 Here's an example of what not to do when calling the function a function `calc_fluseas_mean` (defined above):
 ```


### PR DESCRIPTION
Section 2.2, 2nd bullet, 2nd sentence
Section 5.4 Function calls, 1st sentence: word missing to indicate newline/carriage return